### PR TITLE
Bump puppet-pulp requirement to 3.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
        "name": "katello-pulp",
-       "version_requirement": ">= 2.0.0 < 3.0.0"
+       "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
        "name": "katello-crane",


### PR DESCRIPTION
This was 2.x previously, which is no longer correct.