### PR TITLE
Add paths for puppet-lint docs check

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+---
+Rakefile:
+  param_docs_pattern:
+    - manifests/init.pp

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}
 
 require 'puppet-lint-param-docs/tasks'
 PuppetLintParamDocs.define_selective do |config|
-  config.pattern = []
+  config.pattern = ["manifests/init.pp"]
 end
 
 task :default => [:validate, :lint, :spec]


### PR DESCRIPTION
This checks that each of the class parameters is documented. We need this check
on classes exposed in the installer directly.