### PR TITLE
Prevent 503 errors being return by httpd workers

### DIFF
--- a/templates/_ssl_alias.erb
+++ b/templates/_ssl_alias.erb
@@ -1,6 +1,6 @@
 ProxyPass /pulp !
 ProxyPass /streamer !
-ProxyPass / http://localhost:3000/
+ProxyPass / http://localhost:3000/ retry=0
 ProxyPassReverse / http://localhost:3000
 ProxyPreserveHost on
 RequestHeader set X_FORWARDED_PROTO 'https'


### PR DESCRIPTION
Fusor frequently receives 503 errors while seeding content post install after starting rails. Even if we wait and watch for a 200 response individual workers can respond with a 503 if the retry timeout isn't 0. 

I've managed to coax 503's out of katello devel installer for capsule registration as well by poking at the https://<fqdn> url repeatedly during install after http is up but before rails is up as well, so it's not entirely specific to fusor.