### PR TITLE
Merge puppet-hammer_devel into puppet-katello_devel

### DIFF
--- a/manifests/hammer.pp
+++ b/manifests/hammer.pp
@@ -1,0 +1,18 @@
+# == Class: puppet-hammer_devel
+#
+# Install and configure hammer-cli-katello for development
+#
+class katello_devel::hammer () {
+
+  class { 'katello_devel::hammer::config': } ~>
+  katello_devel::hammer::plugin { 'theforeman/hammer-cli-foreman':
+    config_content => template('katello_devel/hammer/foreman.yml'),
+  } ~>
+  katello_devel::hammer::plugin { 'katello/hammer-cli-katello':
+    config_content => template('katello_devel/hammer/katello.yml'),
+  } ~>
+  katello_devel::hammer::plugin { 'theforeman/hammer-cli-foreman-tasks':
+    config_content => template('katello_devel/hammer/katello.yml'),
+  }
+
+}

--- a/manifests/hammer/config.pp
+++ b/manifests/hammer/config.pp
@@ -1,0 +1,27 @@
+# Configuration for hammer development
+class katello_devel::hammer::config {
+
+  file { ["${katello_devel::deployment_dir}/.hammer/",
+          "${katello_devel::deployment_dir}/.hammer/cli.modules.d/"]:
+    ensure  => 'directory',
+    owner   => $katello_devel::user,
+    mode    => '0644'
+  }
+
+  katello_devel::hammer::plugin { 'theforeman/hammer-cli': }
+
+  file { "${katello_devel::deployment_dir}/hammer-cli/Gemfile.local":
+    ensure  => file,
+    content => template("katello_devel/hammer/Gemfile.local"),
+    owner   => $katello_devel::user,
+    mode    =>  '0644'
+  }
+
+  file { "/var/log/hammer":
+    ensure => directory,
+    owner  => $katello_devel::user,
+    group  => $katello_devel::group,
+    mode   => '0755'
+  }
+
+}

--- a/manifests/hammer/plugin.pp
+++ b/manifests/hammer/plugin.pp
@@ -1,0 +1,30 @@
+# Configuration for hammer development
+class katello_devel::hammer::plugin (
+  $config_content = undef,
+) {
+
+  $split_array = split($name, '/')
+  $github_organization = $split_array[0]
+  $plugin = $split_array[1]
+  $gem_name = regsubst($plugin, '-', '_')
+
+  if $config_content {
+    file { "${katello_devel::deployment_dir}/.hammer/cli.modules.d/${plugin}.yml":
+      ensure  => file,
+      content => $config_content,
+      owner   => $katello_devel::user,
+      mode    => '0644'
+    }
+  }
+
+  git_repo { $plugin:
+    source          => $title,
+    github_username => $katello_devel::github_username,
+  }
+
+  file_line { $katello_devel::hammer_gemfile:
+    line => "gem '${gem_name}', :path => '../${plugin}'",
+    path => "${katello_devel::deployment_dir}/hammer-cli/Gemfile.local"
+  }
+
+}

--- a/templates/hammer/Gemfile.local
+++ b/templates/hammer/Gemfile.local
@@ -1,0 +1,1 @@
+# vim:ft=ruby

--- a/templates/hammer/foreman.yml
+++ b/templates/hammer/foreman.yml
@@ -1,0 +1,5 @@
+:foreman:
+  :enable_module: true
+  :host: 'http://localhost:3000/'
+  :username: 'admin'
+  :password: 'changeme'

--- a/templates/hammer/katello.yml
+++ b/templates/hammer/katello.yml
@@ -1,0 +1,2 @@
+:katello:
+  :enable_module: true


### PR DESCRIPTION
Opening this up for review and comment (needs testing still) based on the general idea and approach. This is taken from adapting https://github.com/Katello/puppet-hammer_devel and combining it with the plugin style approach declaration.