### PR TITLE
puppet4 update for `install_rvm.sh`

### DIFF
--- a/templates/install_rvm.sh.erb
+++ b/templates/install_rvm.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USER=<%= @user %>
+USER=<%= scope['katello_devel::user'] %>
 
 SERVERS=(
     hkp://pgp.mit.edu
@@ -16,4 +16,4 @@ do
         break
     fi
 done
-su -c 'curl -L https://get.rvm.io | bash -s stable --ruby=<%= @rvm_ruby %> --gems=bundler' - $USER
+su -c 'curl -L https://get.rvm.io | bash -s stable --ruby=<%= scope['katello_devel::rvm_ruby'] %> --gems=bundler' - $USER


### PR DESCRIPTION
Previously, this would not fill in `$USER` and would end up executing rvm as
root, causing breakages and confusion.

There was a secondary bug where in some cases, `rvm_path` was being set.
However, I think its OK to assume that `install_rvm.sh` is run on a pristine
system, so I left the bugfix out since it may cause confusion if someone really
does want to set `rvm_path`.