### PR TITLE
Allow pulp via HTTP

### DIFF
--- a/templates/_http.conf.erb
+++ b/templates/_http.conf.erb
@@ -6,5 +6,7 @@ RewriteCond %{REQUEST_URI} !^\/pub\/.*
 RewriteCond %{REQUEST_URI} !^\/pub$
 RewriteCond %{REQUEST_URI} !^\/unattended\/.*
 RewriteCond %{REQUEST_URI} !^\/unattended$
+RewriteCond %{REQUEST_URI} !^\/streamer\/.*
+RewriteCond %{REQUEST_URI} !^\/streamer$
 RewriteCond %{HTTPS} off
 RewriteRule (.*) https://<%= scope['katello_devel::fqdn'] %>/$1 [L,R=301]


### PR DESCRIPTION
Anaconda cannot get https content, so the route files should be also allowed on regular HTTP, as in a production installation.