### PR TITLE
deploy ktest

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -30,4 +30,12 @@ define katello_devel::plugin(
     github_username => $katello_devel::github_username,
   }
 
+  file { '/usr/local/bin/ktest':
+    ensure  => file,
+    content => template('katello_devel/ktest.sh.erb'),
+    owner   => $katello_devel::user,
+    group   => $katello_devel::group,
+    mode    => '0755',
+  }
+
 }

--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Deplyed with katello_devel scenario
+
+FOREMAN_PATH=<%= scope['::katello_devel::deployment_dir'] %>/foreman
+KATELLO_PATH=<%= scope['::katello_devel::deployment_dir'] %>/katello
+
+
+if [[ -n $1 ]]
+then
+  for var in "$@"
+  do
+    if [[ -f $var ]]
+    then
+      TEST_FILES="$TEST_FILES $(readlink -f $var)"
+    else
+      OTHER_OPTS="$OTHER_OPTS $var"
+    fi
+  done
+
+  cd $FOREMAN_PATH
+  RAKE_PATH=`bundle show rake`
+  ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" $TEST_FILES $OTHER_OPTS
+else
+  cd $FOREMAN_PATH
+  bundle exec rake test:katello
+fi


### PR DESCRIPTION
I've made a few changes to the original `ktest` found https://theforeman.org/plugins/katello/developers.html

This allow you to run it from any directory & using relative paths to test files. e.g
```
[vagrant@centos7-devel test]$ pwd
/home/vagrant/katello/test
[vagrant@centos7-devel test]$ ktest models/content_view_test.rb controllers/api/v2/package_groups_controller_test.rb
``` 

OR

```
[vagrant@centos7-devel models]$ pwd
/home/vagrant/katello/test/models
[vagrant@centos7-devel models]$ ktest content_view_test.rb  -ntest_create
```