### PR TITLE
Move ktest to the main class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -220,4 +220,11 @@ class katello_devel (
     candlepin_qpid_exchange => $candlepin_qpid_exchange,
   }
 
+  file { '/usr/local/bin/ktest':
+    ensure  => file,
+    content => template('katello_devel/ktest.sh.erb'),
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+  }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -29,13 +29,4 @@ define katello_devel::plugin(
     source          => $title,
     github_username => $katello_devel::github_username,
   }
-
-  file { '/usr/local/bin/ktest':
-    ensure  => file,
-    content => template('katello_devel/ktest.sh.erb'),
-    owner   => $katello_devel::user,
-    group   => $katello_devel::group,
-    mode    => '0755',
-  }
-
 }

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -8,7 +8,8 @@ describe 'katello_devel' do
       let(:params) do
         {
           :user => 'vagrant',
-          :github_username => 'foo'
+          :github_username => 'foo',
+          :deployment_dir => '/home/vagrant',
         }
       end
 
@@ -19,6 +20,8 @@ describe 'katello_devel' do
       it { should contain_class('katello_devel::install') }
       it { should contain_class('katello_devel::config') }
       it { should contain_class('katello_devel::database') }
+
+      it { should contain_file('/usr/local/bin/ktest').with_content(%r{^FOREMAN_PATH=/home/vagrant/foreman$}) }
     end
   end
 end

--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -2,8 +2,8 @@
 #
 # Deplyed with katello_devel scenario
 
-FOREMAN_PATH=<%= scope['::katello_devel::deployment_dir'] %>/foreman
-KATELLO_PATH=<%= scope['::katello_devel::deployment_dir'] %>/katello
+FOREMAN_PATH=<%= @deployment_dir %>/foreman
+KATELLO_PATH=<%= @deployment_dir %>/katello
 
 
 if [[ -n $1 ]]


### PR DESCRIPTION
This prevents duplicate resource definitions if multiple plugins are used.

Closes GH-110