### PR TITLE
Bump puppetlabs-postgresql version and fix syntax in database.pp

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -39,7 +39,7 @@ class katello_devel::database {
       type        => 'local',
       database    => 'all',
       user        => 'all',
-      order       => '001',
+      order       => 1,
       auth_method => 'trust',
     }
 
@@ -48,7 +48,7 @@ class katello_devel::database {
       database    => 'all',
       user        => 'all',
       address     => '127.0.0.1/32',
-      order       => '002',
+      order       => 2,
       auth_method => 'trust',
     }
 
@@ -57,7 +57,7 @@ class katello_devel::database {
       database    => 'all',
       user        => 'all',
       address     => '::1/128',
-      order       => '003',
+      order       => 3,
       auth_method => 'trust',
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
        "name": "puppetlabs-postgresql",
-       "version_requirement": ">= 3.0.0 < 5.0.0"
+       "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
        "name": "puppetlabs-vcsrepo",


### PR DESCRIPTION
I was bringing up the centos7-devel image and I was getting this error during the foreman-installer step
`Evaluation Error: Error while evaluating a Resource Statement, Postgresql::Server::Pg_hba_rule[local all]: parameter 'order' expects an Integer value, got String  at /usr/share/katello-installer-base/modules/katello_devel/manifests/database.pp:3
8 on node centos7-devel.example.com`

I was able to fix the problem by changing the 'order' attributes from strings to integers. I also bumped the version of puppetlabs-postgres to be < 6.0.0 from < 5.0.0 which matches puppet-foreman.