### PR TITLE
Refactor

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,15 +15,13 @@
 # $post_sync_token::          The shared secret for pulp notifying katello about
 #                             completed syncs
 #
-# $use_passenger::            Whether to use Passenger in development
-#
 # $db_type::                  The database type; 'postgres' or 'sqlite'
-#
-# $mongodb_path::             Path where mongodb should be stored
 #
 # $use_rvm::                  If set to true, will install and configure RVM
 #
 # $rvm_ruby::                 The default Ruby version to use with RVM
+#
+# $qpid_wcache_page_size::    The size (in KB) of the pages in the write page cache
 #
 # $initial_organization::     Initial organization to be created
 #
@@ -53,21 +51,20 @@ class katello_devel (
   String $oauth_key = $katello_devel::params::oauth_key,
   String $oauth_secret = $katello_devel::params::oauth_secret,
   String $post_sync_token = $katello_devel::params::post_sync_token,
-  Boolean $use_passenger = $katello_devel::params::use_passenger,
   Enum['postgres', 'sqlite'] $db_type = $katello_devel::params::db_type,
-  Stdlib::Absolutepath $mongodb_path = $katello_devel::params::mongodb_path,
   Boolean $use_rvm = $katello_devel::params::use_rvm,
   String $rvm_ruby = $katello_devel::params::rvm_ruby,
   String $initial_organization = $katello_devel::params::initial_organization,
   String $initial_location = $katello_devel::params::initial_location,
   String $admin_password = $katello_devel::params::admin_password,
-  Boolean $enable_ostree = $katello::params::enable_ostree,
+  Boolean $enable_ostree = $katello_devel::params::enable_ostree,
   String $candlepin_event_queue = $katello_devel::params::candlepin_event_queue,
   String $candlepin_qpid_exchange = $katello_devel::params::candlepin_qpid_exchange,
   String $github_username = $katello_devel::params::github_username,
   Boolean $use_ssh_fork = $katello_devel::params::use_ssh_fork,
   Optional[String] $fork_remote_name = $katello_devel::params::fork_remote_name,
   String $upstream_remote_name = $katello_devel::params::upstream_remote_name,
+  Integer[0, 1000] $qpid_wcache_page_size = $::katello_devel::params::qpid_wcache_page_size,
   Array[String] $extra_plugins = $katello_devel::params::extra_plugins,
 ) inherits katello_devel::params {
 
@@ -77,83 +74,62 @@ class katello_devel (
 
   $changeme = '$6$lb06/IMy$nZhR3LkR2tUunTQm68INFWMyb/8VA2vfYq0/fRzLoKSfuri.vvtjeLJf9V.wuHzw92.aw8NgUlJchMy/qK25x.'
 
-  user { $katello_devel::user:
+  user { $user:
     ensure     => present,
     managehome => true,
     password   => $changeme,
   } ~>
-  group { $katello_devel::group:
+  group { $group:
     ensure => present,
   }
 
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::ca_cert
 
+  include ::certs::pulp_client
+
   Class['certs'] ~>
   class { '::certs::apache': } ~>
   class { '::katello_devel::apache': } ~>
-  class { '::certs::qpid':
-    require => Class['qpid::install'],
-  } ~>
-  class { '::qpid':
-    ssl                    => true,
-    ssl_cert_db            => $::certs::nss_db_dir,
-    ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
-    ssl_cert_name          => 'broker',
-  } ~>
   class { '::katello_devel::install': } ~>
   class { '::katello_devel::config': } ~>
   class { '::katello_devel::database': } ~>
   class { '::katello_devel::foreman_certs': } ~>
   class { '::katello_devel::setup':
-    require => [
-      Class['pulp'],
-      Class['candlepin'],
-    ],
+    require => Class['katello::candlepin'],
   }
 
-
-  Class['certs'] ~>
-  Class['certs::qpid'] ~>
-  class { '::certs::candlepin': } ~>
-  class { '::candlepin':
-    user_groups                  => $katello_devel::group,
-    oauth_key                    => $katello_devel::oauth_key,
-    oauth_secret                 => $katello_devel::oauth_secret,
-    deployment_url               => 'katello',
-    ca_key                       => $certs::ca_key,
-    ca_cert                      => $certs::ca_cert_stripped,
-    keystore_password            => $::certs::candlepin::keystore_password,
-    truststore_password          => $::certs::candlepin::keystore_password,
-    enable_basic_auth            => false,
-    consumer_system_name_pattern => '.+',
-    adapter_module               => 'org.candlepin.katello.KatelloModule',
-    amq_enable                   => true,
-    amqp_keystore_password       => $::certs::candlepin::keystore_password,
-    amqp_truststore_password     => $::certs::candlepin::keystore_password,
-    amqp_keystore                => $::certs::candlepin::amqp_keystore,
-    amqp_truststore              => $::certs::candlepin::amqp_truststore,
-    require                      => Class['katello_devel::database'],
-    qpid_ssl_cert                => $::certs::qpid::client_cert,
-    qpid_ssl_key                 => $::certs::qpid::client_key,
+  class { '::katello::candlepin':
+    user_groups    => $group,
+    oauth_key      => $oauth_key,
+    oauth_secret   => $oauth_secret,
+    deployment_url => 'katello',
+    db_host        => 'localhost',
+    db_port        => 5432,
+    db_name        => 'candlepin',
+    db_user        => 'candlepin',
+    db_password    => cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32)),
+    db_ssl         => false,
+    db_ssl_verify  => true,
+    manage_db      => true,
+    qpid_hostname  => 'localhost',
+    require        => Class['katello_devel::database'],
   }
 
-  Class['certs'] ~>
-  Class['certs::qpid'] ~>
-  class { '::certs::pulp_client': } ~>
-  class { '::certs::qpid_client': } ~>
+  # TODO: Use ::katello::pulp
+  include ::certs::qpid_client
   class { '::pulp':
     oauth_enabled          => true,
-    oauth_key              => $katello_devel::oauth_key,
-    oauth_secret           => $katello_devel::oauth_secret,
+    oauth_key              => $oauth_key,
+    oauth_secret           => $oauth_secret,
     messaging_url          => 'ssl://localhost:5671',
-    messaging_ca_cert      => $certs::ca_cert,
-    messaging_client_cert  => $certs::qpid_client::messaging_client_cert,
+    messaging_ca_cert      => $::certs::ca_cert,
+    messaging_client_cert  => $::certs::qpid_client::messaging_client_cert,
     messaging_transport    => 'qpid',
     messaging_auth_enabled => false,
     broker_url             => 'qpid://localhost:5671',
     broker_use_ssl         => true,
-    consumers_crl          => $candlepin::crl_file,
+    consumers_crl          => $::candlepin::crl_file,
     manage_broker          => false,
     manage_httpd           => false,
     manage_squid           => true,
@@ -164,19 +140,14 @@ class katello_devel (
     default_password       => 'admin',
     repo_auth              => true,
     enable_ostree          => $enable_ostree,
-  } ~>
-  class { '::qpid::client':
-    ssl                    => true,
-    ssl_cert_name          => 'broker',
-    ssl_cert_db            => $certs::nss_db_dir,
-    ssl_cert_password_file => $certs::qpid::nss_db_password_file,
-  } ~>
+    subscribe              => Class['certs::qpid_client'],
+  }
+
   class { '::katello::qpid':
-    client_cert             => $certs::qpid::client_cert,
-    client_key              => $certs::qpid::client_key,
     katello_user            => $user,
     candlepin_event_queue   => $candlepin_event_queue,
     candlepin_qpid_exchange => $candlepin_qpid_exchange,
+    wcache_page_size        => $qpid_wcache_page_size,
   }
 
   file { '/usr/local/bin/ktest':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,10 @@ class katello_devel (
     ensure => present,
   }
 
+  $foreman_url = "https://${::fqdn}/"
+  $candlepin_url = "https://${::fqdn}:8443/candlepin"
   $candlepin_ca_cert = $::certs::ca_cert
+  $pulp_url      = "https://${::fqdn}/pulp/api/v2/"
   $pulp_ca_cert = $::certs::ca_cert
 
   include ::certs::pulp_client

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,8 @@ class katello_devel (
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_url      = "https://${::fqdn}/pulp/api/v2/"
   $pulp_ca_cert = $::certs::ca_cert
+  $qpid_hostname = 'localhost'
+  $qpid_url = "amqp:ssl:${qpid_hostname}:5671"
 
   include ::certs::pulp_client
 
@@ -115,7 +117,7 @@ class katello_devel (
     db_ssl         => false,
     db_ssl_verify  => true,
     manage_db      => true,
-    qpid_hostname  => 'localhost',
+    qpid_hostname  => $qpid_hostname,
     require        => Class['katello_devel::database'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,11 @@
 # Katello development parameters
-class katello_devel::params() inherits ::katello::params { # lint:ignore:inherits_across_namespaces
+class katello_devel::params {
   $user = undef
 
-  $use_passenger = false
   $oauth_key          = cache_data('foreman_cache_data', 'oauth_consumer_key', random_password(32))
   $oauth_secret       = cache_data('foreman_cache_data', 'oauth_consumer_secret', random_password(32))
 
   $db_type = 'sqlite'
-  $mongodb_path  = '/var/lib/mongodb'
 
   $deployment_dir = '/home/vagrant'
 
@@ -27,4 +25,9 @@ class katello_devel::params() inherits ::katello::params { # lint:ignore:inherit
   $upstream_remote_name = 'upstream'
 
   $extra_plugins = []
+
+  $candlepin_event_queue = 'katello_event_queue'
+  $candlepin_qpid_exchange = 'event'
+
+  $qpid_wcache_page_size = 4
 }

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -1,13 +1,10 @@
 ### File managed with puppet ###
-## Module: puppet-katello
+## Module: puppet-katello_devel
 
 :katello:
-  <%- unless [nil, :undefined, :undef].include?(scope['katello_devel::cdn_ssl_version']) -%>
-  :cdn_ssl_version: <%= scope['katello_devel::cdn_ssl_version']%>
-  <%- end -%>
   :rest_client_timeout: 3600
 
-  :post_sync_url: https://<%= scope['katello_devel::fqdn'] %><%= scope['katello_devel::deployment_url'] %>/api/v2/repositories/sync_complete?token=<%= scope['katello_devel::post_sync_token'] %>
+  :post_sync_url: https://<%= scope['katello_devel::foreman_url'] %>/api/v2/repositories/sync_complete?token=<%= scope['katello_devel::post_sync_token'] %>
 
   :candlepin:
     :url: <%= scope['katello_devel::candlepin_url'] %>
@@ -24,11 +21,3 @@
   :qpid:
     :url: <%= scope['katello_devel::qpid_url'] %>
     :subscriptions_queue_address: <%= scope['katello_devel::candlepin_event_queue'] %>
-
-<%- unless [nil, :undefined, :undef].include?(scope['katello_devel::proxy_url']) -%>
-  :cdn_proxy:
-    :host: <%= scope['katello_devel::proxy_url'] %>
-    :port: <%= scope['katello_devel::proxy_port'] %>
-    :user: <%= scope['katello_devel::proxy_username'] %>
-    :password: <%= scope['katello_devel::proxy_password'] %>
-<%- end -%>


### PR DESCRIPTION
This is the initial commit that refactors the module a bit. It starts to depend more on katello-katello to do the actual backend services installs.

It removes two unused parameters and no longer uses katello::params but instead uses local variables.

The goal is to use katello-katello for every service except the application. For that we continue doing a git install.