### PR TITLE
Install qpid-cpp-client-devel package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # Katello Development Install
 class katello_devel::install {
 
-  package{ ['pulp-katello', 'libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'libxml2-devel', 'git']:
+  package{ ['pulp-katello', 'libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'libxml2-devel', 'git', 'qpid-cpp-client-devel']:
     ensure => present,
   }
 


### PR DESCRIPTION
bundle install fails without this package
because qpid gem has unmet dependencies