### PR TITLE
Add missing parameters for katello::qpid

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,8 @@ class katello_devel (
   }
 
   class { '::katello::qpid':
+    interface               => 'lo',
+    hostname                => 'localhost',
     katello_user            => $user,
     candlepin_event_queue   => $candlepin_event_queue,
     candlepin_qpid_exchange => $candlepin_qpid_exchange,


### PR DESCRIPTION
The class now has 2 additional parameters which we need to specify. This
copies the defaults.